### PR TITLE
Fixing reference to external pods not compiling

### DIFF
--- a/Classes/UIScrollView+infiniteScrolling.m
+++ b/Classes/UIScrollView+infiniteScrolling.m
@@ -7,8 +7,8 @@
 //
 
 #import "UIScrollView+infiniteScrolling.h"
-#import <UIView+TKGeometry.h>
-#import <JRSwizzle.h>
+#import <UIView+TKGeometry/UIView+TKGeometry.h>
+#import <JRSwizzle/JRSwizzle.h>
 #import <objc/runtime.h>
 
 @implementation UIView (infiniteScrollRemoveAllSubviews)


### PR DESCRIPTION
When compiling with `use_frameworks!` it wouldn't work unless you include the framework the file belonged to.