### PR TITLE
Use module import for UIView+TKGeometry

### DIFF
--- a/Classes/UIScrollView+infiniteScrolling.m
+++ b/Classes/UIScrollView+infiniteScrolling.m
@@ -7,9 +7,10 @@
 //
 
 #import "UIScrollView+infiniteScrolling.h"
-#import <UIView+TKGeometry/UIView+TKGeometry.h>
 #import <JRSwizzle/JRSwizzle.h>
 #import <objc/runtime.h>
+
+@import UIView_TKGeometry;
 
 @implementation UIView (infiniteScrollRemoveAllSubviews)
 


### PR DESCRIPTION
I'm migrating an Objective-C project to Swift and I added `use_frameworks!` to my `Podfile` but then I got an error in `UIScrollView+infiniteScrolling.m` in this line `#import <UIView+TKGeometry/UIView+TKGeometry.h>`. I was able to fix it by changing it to import the module like this `@import UIView_TKGeometry;`.